### PR TITLE
feat: update proof of subscription

### DIFF
--- a/programs/plege/src/error/mod.rs
+++ b/programs/plege/src/error/mod.rs
@@ -1,9 +1,11 @@
 use anchor_lang::prelude::*;
 
 #[error_code]
-pub enum PledgeError {
+pub enum PlegeError {
     #[msg("Invalid tier id")]
     InvalidAppId,
     #[msg("Invalid tier id")]
     InvalidTierId,
+    #[msg("Payment interval skipped")]
+    MissedPayment,
 }

--- a/programs/plege/src/instructions/create_app.rs
+++ b/programs/plege/src/instructions/create_app.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::error::PledgeError;
+use crate::error::PlegeError;
 use crate::state::*;
 
 #[derive(Accounts)]
@@ -18,7 +18,7 @@ pub struct CreateApp<'info> {
         seeds = ["USER_META".as_bytes(), auth.key().as_ref()],
         bump,
         has_one = auth,
-        constraint = app_id == user_meta.num_apps + 1 @ PledgeError::InvalidAppId,
+        constraint = app_id == user_meta.num_apps + 1 @ PlegeError::InvalidAppId,
     )]
     pub user_meta: Account<'info, UserMeta>,
     /// CHECK: Arbitrary treasury account chosen by app creator

--- a/programs/plege/src/instructions/create_subscription.rs
+++ b/programs/plege/src/instructions/create_subscription.rs
@@ -42,8 +42,7 @@ pub fn create_subscription(ctx: Context<CreateSubscription>) -> Result<()> {
     subscription.subscriber = subscriber.clone().key();
     // subscription.expiration = Clock::get().unwrap().unix_timestamp + (tier.interval as i64);
     subscription.start = Clock::get().unwrap().unix_timestamp;
-    subscription.amount_paid = 0;
-    subscription.active = true;
+    subscription.active_through = subscription.start;
     subscription.bump = *ctx.bumps.get("subscription").unwrap();
 
     // approve

--- a/programs/plege/src/instructions/create_tier.rs
+++ b/programs/plege/src/instructions/create_tier.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::Mint;
 
 use crate::state::*;
-use crate::error::PledgeError;
+use crate::error::PlegeError;
 
 #[derive(Accounts)]
 #[instruction(tier_id: u8)]
@@ -16,7 +16,7 @@ pub struct CreateTier<'info> {
     pub tier: Account<'info, Tier>,
     #[account(
         mut,
-        constraint = tier_id == app.num_tiers + 1 @ PledgeError::InvalidTierId
+        constraint = tier_id == app.num_tiers + 1 @ PlegeError::InvalidTierId
     )]
     pub app: Account<'info, App>,
     pub mint: Account<'info, Mint>,

--- a/programs/plege/src/instructions/toggle_new_subscribers.rs
+++ b/programs/plege/src/instructions/toggle_new_subscribers.rs
@@ -1,8 +1,5 @@
-use anchor_lang::prelude::*;
-use anchor_spl::token::Mint;
-
-use crate::error::PledgeError;
 use crate::state::*;
+use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct ToggleNewSubscribers<'info> {

--- a/programs/plege/src/state/interval.rs
+++ b/programs/plege/src/state/interval.rs
@@ -1,0 +1,33 @@
+use anchor_lang::prelude::borsh;
+use borsh::{BorshDeserialize, BorshSerialize};
+use chrono::*;
+
+#[derive(Copy, Clone, BorshDeserialize, BorshSerialize)]
+pub enum Interval {
+    Month,
+    Year,
+}
+
+impl Interval {
+    pub fn max_approval_len(self) -> u64 {
+        match self {
+            Interval::Month => 60,
+            Interval::Year => 6,
+        }
+    }
+
+    pub fn increment(self, current: i64) -> i64 {
+        let start = NaiveDateTime::from_timestamp_opt(current, 0).unwrap();
+
+        match self {
+            Interval::Month => start
+                .checked_add_months(Months::new(1))
+                .unwrap()
+                .timestamp(),
+            Interval::Year => start
+                .checked_add_months(Months::new(12))
+                .unwrap()
+                .timestamp(),
+        }
+    }
+}

--- a/programs/plege/src/state/mod.rs
+++ b/programs/plege/src/state/mod.rs
@@ -1,10 +1,11 @@
 mod app;
+mod interval;
 mod subscription;
 mod tier;
 mod user;
 
 pub use app::*;
+pub use interval::Interval;
 pub use subscription::*;
 pub use tier::*;
 pub use user::*;
-pub use Interval;

--- a/programs/plege/src/state/subscription.rs
+++ b/programs/plege/src/state/subscription.rs
@@ -1,4 +1,3 @@
-use crate::borsh::{BorshDeserialize, BorshSerialize};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -7,7 +6,6 @@ pub struct Subscription {
     pub tier: Pubkey,
     pub subscriber: Pubkey,
     pub start: i64,
-    pub amount_paid: u64,
-    pub active: bool,
+    pub active_through: i64,
     pub bump: u8,
 }

--- a/programs/plege/src/state/tier.rs
+++ b/programs/plege/src/state/tier.rs
@@ -1,4 +1,4 @@
-use crate::borsh::{BorshDeserialize, BorshSerialize};
+use super::interval::Interval;
 use anchor_lang::prelude::*;
 
 #[account]
@@ -10,19 +10,4 @@ pub struct Tier {
     pub interval: Interval,
     pub accepting_new_subs: bool,
     pub active: bool,
-}
-
-#[derive(Copy, Clone, BorshDeserialize, BorshSerialize)]
-pub enum Interval {
-    Month,
-    Year,
-}
-
-impl Interval {
-    pub fn max_approval_len(self) -> u64 {
-        match self {
-            Interval::Month => 60,
-            Interval::Year => 6,
-        }
-    }
 }

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -75,11 +75,14 @@ describe("basic flow", () => {
     )
     const startTime = new Date(subscriptionPDA.start * 1000)
     expect(new Date().getTime() - startTime.getTime()).to.be.lessThan(5000)
-    expect(subscriptionPDA.amountPaid.toNumber()).to.equal(0)
-    expect(subscriptionPDA.active).to.equal(true)
+    expect(subscriptionPDA.start.toNumber()).to.equal(
+      subscriptionPDA.activeThrough.toNumber()
+    )
   })
 
   it("completes payment", async () => {
+    const before = await global.program.account.subscription.fetch(subscription)
+
     await global.program.methods
       .completePayment()
       .accounts({
@@ -97,7 +100,11 @@ describe("basic flow", () => {
 
     const ownerATA = await getAccount(global.connection, colossalAta)
 
-    expect(subscriptionPDA.amountPaid.toNumber()).to.equal(10)
+    let payPeriod = new Date(before.activeThrough.toNumber() * 1000)
+    payPeriod.setMonth(payPeriod.getMonth() + 1)
+    expect(subscriptionPDA.activeThrough.toNumber() * 1000).to.equal(
+      payPeriod.getTime()
+    )
     expect(Number(ownerATA.amount)).to.equal(10)
   })
 
@@ -140,8 +147,9 @@ describe("basic flow", () => {
     )
     const startTime = new Date(subscriptionPDA.start * 1000)
     expect(new Date().getTime() - startTime.getTime()).to.be.lessThan(5000)
-    expect(subscriptionPDA.amountPaid.toNumber()).to.equal(0)
-    expect(subscriptionPDA.active).to.equal(true)
+    expect(subscriptionPDA.start.toNumber()).to.equal(
+      subscriptionPDA.activeThrough.toNumber()
+    )
   })
 
   before(async () => {


### PR DESCRIPTION
now uses `active_through` on `Subscription` type to prove whether or not subscription is active. There is no `active` property anymore, nor is there an `amount_paid` property.